### PR TITLE
WP API: Allow calling WP API endpoints

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -11,8 +11,9 @@ var config       = require('../config.json'),
     authScheme   = require('./auth')(config);
 
 $(function() {
-
-var authPanel = new ui.AuthPanel('#auth', {
+var
+    apiSelector = new ui.OptionSelector($('#api-selector'), { values: ['WP.COM', 'WP.CORE'] } ),
+    authPanel = new ui.AuthPanel('#auth', {
       'scheme': auth,
       'onCheckToken' : function(auth, callback) {
         sendRequest({path:'/v1/me'}, callback);
@@ -35,6 +36,10 @@ var authPanel = new ui.AuthPanel('#auth', {
       },
       'onLoadEndpoints': function(version, onEndpoints) {
         // TODO: stash endpoints in local storage so we can load them immediately in the future
+        if (apiSelector.getValue() === 'WP.CORE') {
+            return onEndpoints(null, []);
+        }
+
         $.ajax({
           headers: { 'accept': 'application/json' },
           url: "https://public-api.wordpress.com/rest/v" + version +"/help",
@@ -124,6 +129,13 @@ var authPanel = new ui.AuthPanel('#auth', {
       return viewer;
     };
 
+apiSelector.on('change', function(){
+  var api = apiSelector.getValue();
+  authPanel.switchApi(api);
+  referencePanel.switchApi(api);
+  pathField.reset();
+});
+
 bodyBuilder.disable();
 
 methodSelector.on('enabled', function(){
@@ -208,6 +220,7 @@ pathField.on('submit', function(path){
 
   request.path = a.pathname;
   request.query = a.search.substring(1, a.search.length);
+  request.api = apiSelector.getValue();
 
   sendRequest(request).focus();
 
@@ -220,8 +233,8 @@ try {
   // unable to load history
 }
 
-referencePanel.on('history', function(endpoints) {
-  localStorage.history = JSON.stringify(endpoints);
+referencePanel.on('history', function(history) {
+  localStorage.history = JSON.stringify(history);
 });
 
 referencePanel.on('change', function() {

--- a/lib/auth/oauth.js
+++ b/lib/auth/oauth.js
@@ -55,11 +55,15 @@ function sendRequest(req, callback) {
   // TODO: format the request correctly before sending
   // check the version
   // clean up the path in case it's an absolute URI
-  const version = req.version || '1';
+  var version = req.version || '1';
+  var api = req.api || 'WP.COM';
+  var basePath = api === 'WP.COM'
+    ? 'https://public-api.wordpress.com/rest/v' + version
+    : 'https://public-api.wordpress.com/wp/v2';
 
   $.ajax({
     type: req.method,
-    url: 'https://public-api.wordpress.com/rest/v' + version + req.path + (req.query ? "?" + req.query : '' ),
+    url: basePath + req.path + (req.query ? "?" + req.query : '' ),
     data: req.method == 'GET' ? null : req.body,
     headers: $.extend({'accept':'application/json'}, authHeaders()),
     success: function(data, status, xhr) {

--- a/lib/search.js
+++ b/lib/search.js
@@ -2,7 +2,6 @@ var liquidmetal = require('liquidmetal');
 
 
 onmessage = function(e) {
-
   var start = new Date().getTime(),
       query = e.data.query,
       index = e.data.index,
@@ -37,4 +36,3 @@ onmessage = function(e) {
 
   postMessage({query: query, results: results, ms: end-start});
 };
-

--- a/lib/ui/auth_panel.js
+++ b/lib/ui/auth_panel.js
@@ -37,8 +37,8 @@ var AuthPanel = Component.extend({
     this.extra = $('<span></span>').appendTo(this.node).addClass(this.options.extraClass).text(this.options.signInText);
     this.img = $('<span></span>').appendTo(this.node).addClass(this.options.imgClass);
     this.avatar = $('<img>').appendTo(this.img).hide();
-
     this.throbber = $('<div><div></div></div>').addClass('throbber').appendTo(this.node);
+    this.api = 'WP.COM';
   }
 });
 
@@ -94,7 +94,6 @@ AuthPanel.prototype.onKeypress = function(e) {
 };
 
 AuthPanel.prototype.detectActive = function(e) {
-
   var node = this.node,
       cls = this.options.activeClass;
 
@@ -106,7 +105,10 @@ AuthPanel.prototype.detectActive = function(e) {
     }, 200);
 
   }
-
 };
+
+AuthPanel.prototype.switchApi = function(api) {
+  this.api = api;
+}
 
 module.exports = AuthPanel;

--- a/lib/ui/reference_panel.js
+++ b/lib/ui/reference_panel.js
@@ -7,13 +7,14 @@ var Component = require('./component'),
 var ReferencePanel = Component.extend({
   'openClass'       : 'open',
   'browserClass'    : 'browser',
-  'history'         : [],
+  'history'         : {},
   'search_url'      : null,
   'filter'          : function(){ return arguments[0]; },
   'onSelect'        : function(){},
   'onLoadVersions'  : function(){},
   'onLoadEndpoints' : function(){},
   'init' : function(node, options) {
+    this.api = 'WP.COM';
     this.onSearch = this.search.bind(this);
     this.onReference = this.partitionedEndpoints.bind(this);
     this.groupsList = new ListComponent({
@@ -167,7 +168,7 @@ ReferencePanel.prototype.onOpen = function() {
 
 ReferencePanel.prototype.onClose = function() {
   this.groupsList.disable();
-  this.endpointsList.disable();  
+  this.endpointsList.disable();
 };
 
 ReferencePanel.prototype.getEndpoints = function() {
@@ -184,8 +185,8 @@ ReferencePanel.prototype.partitionedEndpoints = function() {
     all = all.concat(grouped[group]);
   });
 
-  if(this.options.history.length > 0) {
-    all = [{history: true, label: 'Recent'}].concat(this.options.history).concat(all);
+  if(this.options.history && this.options.history[this.api] && this.options.history[this.api].length > 0) {
+    all = [{history: true, label: 'Recent'}].concat(this.options.history[this.api]).concat(all);
   }
   return all;
 };
@@ -214,7 +215,6 @@ ReferencePanel.prototype.search = function(q, callback) {
     callback(this.partitionedEndpoints());
     return;
   }
-
   this.ranker.postMessage({query: q, index: this.getEndpoints()});
   this.onRanking = callback;
 
@@ -241,21 +241,33 @@ ReferencePanel.prototype.onEndpoints = function(version, err, endpoints) {
   if (this.onLoadingComplete) this.onLoadingComplete();
 };
 
-ReferencePanel.prototype.setHistory = function(endpoints) {
-  this.options.history = endpoints;
+ReferencePanel.prototype.setHistory = function(history) {
+  this.options.history = history;
 };
 
 ReferencePanel.prototype.addHistory = function(endpoint) {
-  if (!this.options.history) this.options.history = [];
+  if (!this.options.history) this.options.history = {};
+  if (!this.options.history[this.api]) this.options.history[this.api] = [];
 
-  this.options.history = this.options.history.filter(function(item) {
+
+  this.options.history[this.api] = this.options.history[this.api].filter(function(item) {
     return !(item.path_labeled == endpoint.path_labeled && item.method == endpoint.method);
   }).slice(0, 10);
 
-  this.options.history.unshift(endpoint);
+  this.options.history[this.api].unshift(endpoint);
 
   this.emit('history', this.options.history);
-
 };
+
+ReferencePanel.prototype.switchApi = function(api) {
+  this.api = api;
+  if (api === 'WP.CORE') {
+    this.versionOption.node.hide();
+  } else {
+    this.versionOption.node.show();
+  }
+  var version = this.versionOption.getValue();
+  this.options.onLoadEndpoints(version, fn.arglock(this.onEndpoints, version).bind(this));
+}
 
 module.exports = ReferencePanel;

--- a/templates/sass/style.scss
+++ b/templates/sass/style.scss
@@ -88,7 +88,7 @@ div#path {
     background: hsl(202,68%,100%);
   }
 
-  #versions {
+  #versions, #api-selector {
     top: 0;
     background: $dark;
     color: white;
@@ -105,9 +105,7 @@ div#path {
       right: 8px;
       top: 8px;
     }
-
   }
-
 }
 
 div#parts {
@@ -372,7 +370,7 @@ div.param {
   padding: 2px 20px 0 4px;
   line-height: 24px;
   @include flex(0,0);
-  
+
   #path & {
     font-family: Inconsolata, monospace;
     font-size: 16px;
@@ -406,7 +404,7 @@ div.param {
     background: transparent;
 
     &::after {
-      visibility: hidden; 
+      visibility: hidden;
     }
 
     &:hover, &:active, &:focus {
@@ -502,7 +500,7 @@ div#submit {
   position: relative;
 
   @include flex(0,0);
-  
+
 
   a {
     position: absolute;
@@ -747,7 +745,7 @@ section#parameters {
    border-bottom: 1px solid hsl(205,38%,94%);
    padding: 0;
  }
- 
+
  tr:last-child {
    th, td {
      border-bottom: none;
@@ -1191,7 +1189,7 @@ code {
 
   header {
     @include flex(0,0);
-    
+
     h2 {
       font-size: 14px;
       font-weight: normal;
@@ -1266,7 +1264,7 @@ code {
         display: block;
         color: $dark;
       }
-      
+
       .description {
         display: block;
         font-size: 14px;

--- a/templates/views/app.jade
+++ b/templates/views/app.jade
@@ -23,6 +23,7 @@ html(lang="en")
 
   body
     #path
+      #api-selector
       #auth(tabindex="2")
       #versions
       #lookup-container


### PR DESCRIPTION
  - Display a switch between WP.COM API and WP API
  - For now we can type custom requests but we can not select endpoints yet

<img width="727" alt="capture d ecran 2016-10-20 a 9 17 00 am" src="https://cloud.githubusercontent.com/assets/272444/19552078/29fef9f4-96a6-11e6-9420-7d605da32f1f.png">

The API describing the endpoints is not the same between WP-API and WP.COM, so we may need an adapter in order to display the endpoints correctly