### PR TITLE
Add console message hinting at return value in window.response

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -307,6 +307,8 @@ app
 .on('success', function(response) {
   window.response = response;
   window.responses.unshift(response);
+
+  console.log('%c window.response ready with ' + Object.keys(response).length + ' keys. Previous responses in window.responses[].', 'color: #cccccc;');
 })
 .on('error', function(error, request, xhr) {
   window.error = {

--- a/lib/app.js
+++ b/lib/app.js
@@ -300,25 +300,27 @@ window.send = sendRequest;
 
 window.responses = [];
 window.response = null;
-window.errors = [];
-window.error = {};
 
-app
-.on('success', function(response) {
+function recordResponse(response) {
   window.response = response;
   window.responses.unshift(response);
 
   console.log('%c window.response ready with ' + Object.keys(response).length + ' keys. Previous responses in window.responses[].', 'color: #cccccc;');
+}
+
+app
+.on('success', function(response) {
+  recordResponse(response);
 })
 .on('error', function(error, request, xhr) {
-  window.error = {
+  var errorDetails = {
     request: request,
     status: error.status,
     error: error,
     xhr: xhr,
   };
-  window.errors.unshift(window.error);
-  console.warn('API error', window.error);
+  console.warn(errorDetails);
+  recordResponse(errorDetails);
 });
 
 }); // $();


### PR DESCRIPTION
This PR adds a `console.log` message noticing of the availability of the response value in the console.

<img width="544" alt="screen shot 2016-10-25 at 15 40 18" src="https://cloud.githubusercontent.com/assets/4389/19688276/5eee756e-9ac9-11e6-8290-b55b90a86e0e.png">

Would be nice to add to it a timestamp or some more details about the return value, but I think the important part is to make people aware it's available.

Related to #9.

/cc @beaucollins  
